### PR TITLE
Introduce core builders for DPHS configuration

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -14,4 +14,5 @@ We provide some examples coming from our `publications <biblio>`_.
    examples/wave_coenergy
    examples/heat_wave
    examples/shallow_water
+   examples/builder_quickstart
    

--- a/docs/source/examples/builder_quickstart.rst
+++ b/docs/source/examples/builder_quickstart.rst
@@ -1,0 +1,18 @@
+Builder quickstart
+==================
+
+The new builder API lets you register domain, states and ports in a fluent fashion::
+
+    from scrimp import CoState, DPHS, Domain, State
+
+    domain = Domain("Interval", {"L": 1.0, "h": 0.2})
+    dphs = DPHS()
+
+    state = State("x", "displacement", "scalar-field")
+    costate = CoState("p", "momentum", state)
+
+    dphs.builder.with_domain(domain).add_state(state).add_costate(costate)
+
+    print(list(dphs.ports))
+
+See :mod:`examples.builder_quickstart` for a complete script.

--- a/docs/source/scrimp.rst
+++ b/docs/source/scrimp.rst
@@ -22,6 +22,17 @@ Distributed port-Hamiltonian system
    :undoc-members:
    :show-inheritance:
 
+Core building blocks
+====================
+
+.. automodule:: scrimp.core.system
+   :members:
+   :undoc-members:
+
+.. automodule:: scrimp.core.builder
+   :members:
+   :undoc-members:
+
 Domain
 ======
 

--- a/examples/builder_quickstart.py
+++ b/examples/builder_quickstart.py
@@ -1,0 +1,20 @@
+"""Minimal example showcasing the declarative builder workflow."""
+
+from scrimp import CoState, DPHS, Domain, State
+
+
+def build_single_state_model() -> DPHS:
+    domain = Domain("Interval", {"L": 1.0, "h": 0.2})
+    dphs = DPHS()
+
+    state = State("x", "displacement", "scalar-field", mesh_id=0)
+    costate = CoState("p", "momentum", state)
+
+    dphs.builder.with_domain(domain).add_state(state).add_costate(costate)
+
+    return dphs
+
+
+if __name__ == "__main__":
+    model = build_single_state_model()
+    print("Registered ports:", list(model.ports))

--- a/scrimp/__init__.py
+++ b/scrimp/__init__.py
@@ -28,6 +28,7 @@ import scrimp.utils.config
 scrimp.utils.config.set_paths()
 scrimp.utils.config.set_verbose(1)
 
+from scrimp.core import IORegistry, StateSpace, SystemTopology, TimeIntegrator, TopologyBuilder
 from scrimp.dphs import DPHS
 from scrimp.domain import Domain
 from scrimp.state import State
@@ -37,3 +38,22 @@ from scrimp.fem import FEM
 from scrimp.control import Control_Port
 from scrimp.brick import Brick
 from scrimp.hamiltonian import Term, Hamiltonian
+
+__all__ = [
+    "DPHS",
+    "Domain",
+    "State",
+    "CoState",
+    "Parameter",
+    "Port",
+    "FEM",
+    "Control_Port",
+    "Brick",
+    "Term",
+    "Hamiltonian",
+    "IORegistry",
+    "StateSpace",
+    "SystemTopology",
+    "TimeIntegrator",
+    "TopologyBuilder",
+]

--- a/scrimp/core/__init__.py
+++ b/scrimp/core/__init__.py
@@ -1,0 +1,12 @@
+"""Core building blocks used to describe SCRIMP models."""
+
+from .system import SystemTopology, StateSpace, TimeIntegrator, IORegistry
+from .builder import TopologyBuilder
+
+__all__ = [
+    "SystemTopology",
+    "StateSpace",
+    "TimeIntegrator",
+    "IORegistry",
+    "TopologyBuilder",
+]

--- a/scrimp/core/builder.py
+++ b/scrimp/core/builder.py
@@ -1,0 +1,76 @@
+"""Declarative helpers to populate :mod:`scrimp.dphs` models."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from scrimp.core.system import IORegistry, StateSpace, SystemTopology
+from scrimp.costate import CoState
+from scrimp.port import Port
+from scrimp.state import State
+
+
+class TopologyBuilder:
+    """Fluent helper that wires states, costates and ports together."""
+
+    def __init__(
+        self,
+        topology: Optional[SystemTopology] = None,
+        state_space: Optional[StateSpace] = None,
+        io_registry: Optional[IORegistry] = None,
+        port_callback: Optional[Callable[[Port], None]] = None,
+    ) -> None:
+        self.topology = topology or SystemTopology()
+        self.state_space = state_space or StateSpace()
+        self.io_registry = io_registry or IORegistry()
+        self._port_callback = port_callback
+
+    def with_domain(self, domain) -> "TopologyBuilder":
+        """Attach a domain to the system topology."""
+
+        self.topology.set_domain(domain)
+        return self
+
+    def add_state(self, state: State) -> "TopologyBuilder":
+        """Register a state variable."""
+
+        self.state_space.register_state(state)
+        return self
+
+    def add_costate(self, costate: CoState) -> "TopologyBuilder":
+        """Register a co-state and automatically generate its dynamical port."""
+
+        state = costate.get_state()
+        if state.get_costate() is None:
+            state.set_costate(costate)
+        self.state_space.register_costate(costate)
+
+        port = Port(
+            state.get_name(),
+            state.get_name(),
+            costate.get_name(),
+            costate.get_kind(),
+            state.get_mesh_id(),
+            algebraic=False,
+            dissipative=False,
+            substituted=costate.get_substituted(),
+            region=state.get_region(),
+        )
+        self.add_port(port)
+        state.set_port(port)
+        costate.set_port(port)
+        return self
+
+    def add_port(self, port: Port) -> "TopologyBuilder":
+        """Register a (possibly external) port."""
+
+        self.io_registry.register_port(port)
+        if self._port_callback is not None:
+            self._port_callback(port)
+        return self
+
+    def build(self) -> tuple[SystemTopology, StateSpace, IORegistry]:
+        """Return the composed managers."""
+
+        return self.topology, self.state_space, self.io_registry
+

--- a/scrimp/core/system.py
+++ b/scrimp/core/system.py
@@ -1,0 +1,87 @@
+"""Light-weight containers describing the structural components of a DPHS model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, TYPE_CHECKING, Any
+
+from scrimp.hamiltonian import Hamiltonian
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    from scrimp.brick import Brick
+    from scrimp.control import Control_Port
+    from scrimp.costate import CoState
+    from scrimp.domain import Domain
+    from scrimp.port import Port
+    from scrimp.state import State
+
+
+@dataclass
+class SystemTopology:
+    """Store the meshes, bricks and domains making up a model."""
+
+    domain: Optional["Domain"] = None
+    bricks: Dict[str, "Brick"] = field(default_factory=dict)
+
+    def set_domain(self, domain: "Domain") -> None:
+        """Attach a domain to the topology."""
+
+        self.domain = domain
+
+
+@dataclass
+class StateSpace:
+    """Keep track of state and costate variables registered in the model."""
+
+    states: Dict[str, "State"] = field(default_factory=dict)
+    costates: Dict[str, "CoState"] = field(default_factory=dict)
+
+    def register_state(self, state: "State") -> None:
+        """Register a new state instance."""
+
+        self.states[state.get_name()] = state
+
+    def register_costate(self, costate: "CoState") -> None:
+        """Register a new costate instance."""
+
+        self.costates[costate.get_name()] = costate
+
+
+@dataclass
+class IORegistry:
+    """Collect boundary ports, control ports and Hamiltonian terms."""
+
+    ports: Dict[str, "Port"] = field(default_factory=dict)
+    controls: Dict[str, "Control_Port"] = field(default_factory=dict)
+    hamiltonian: Hamiltonian = field(default_factory=lambda: Hamiltonian("Hamiltonian"))
+    powers_computed: bool = False
+
+    def register_port(self, port: "Port") -> None:
+        self.ports[port.get_name()] = port
+
+    def register_control(self, control: "Control_Port") -> None:
+        self.controls[control.get_name()] = control
+
+
+@dataclass
+class TimeIntegrator:
+    """Handle PETSc TS option bookkeeping and solution storage."""
+
+    options: Dict[str, Any] = field(default_factory=dict)
+    initial_values: Dict[str, bool] = field(default_factory=dict)
+    solution: Dict[str, List[Any]] = field(
+        default_factory=lambda: {"t": [], "z": []}
+    )
+    stop: bool = False
+    ts_start: float = 0.0
+
+    def reset_options(self) -> None:
+        """Clear the PETSc options database."""
+
+        self.options = {}
+
+    def reset_solution(self) -> None:
+        """Clear previously stored solutions."""
+
+        self.solution = {"t": [], "z": []}
+

--- a/scrimp/dphs.py
+++ b/scrimp/dphs.py
@@ -14,7 +14,13 @@
 """
 
 from scrimp.utils.linalg import convert_gmm_to_petsc, extract_gmm_to_scipy
-from scrimp.hamiltonian import Hamiltonian
+from scrimp.core import (
+    IORegistry,
+    StateSpace,
+    SystemTopology,
+    TimeIntegrator,
+    TopologyBuilder,
+)
 from scrimp.brick import Brick
 from scrimp.control import Control_Port
 from scrimp.fem import FEM
@@ -58,24 +64,20 @@ class DPHS:
             basis_field (str): basis field for unknowns (must be `real` or `complex`)
         """
 
-        #: The `domain` of a dphs is an object that handle mesh(es) and dict of regions with getfem indices (for each mesh), useful to define `bricks` (i.e. forms) in the getfem syntax
-        self.domain = None
+        #: Core managers describing the topology, state space and IO of the model
+        self._topology = SystemTopology()
+        self._state_space = StateSpace()
+        self._io_registry = IORegistry()
+        self.builder = TopologyBuilder(
+            topology=self._topology,
+            state_space=self._state_space,
+            io_registry=self._io_registry,
+            port_callback=self._on_port_registered,
+        )
+
         #: Clear and init `time_scheme` member, which embed PETSc TS options database
+        self._time_integrator = TimeIntegrator()
         self.get_cleared_TS_options()
-        #: The dict of `states`, store many infos for display()
-        self.states = dict()
-        #: The dict of `costates`, store many infos for display()
-        self.costates = dict()
-        #: The dict of `ports`, store many infos for display()
-        self.ports = dict()
-        #: The dict of `bricks`, associating getfem `bricks` to petsc matrices obtained by the PFEM, store many infos for display()
-        self.bricks = dict()
-        #: The dict of `controls`, collecting information about control ports. Also appear in `ports` entries
-        self.controls = dict()
-        #: The `Hamiltonian` of a dphs is a list of dict containing several useful information for each term
-        self.hamiltonian = Hamiltonian("Hamiltonian")
-        #: To check if the powers have been computed
-        self.powers_computed = False
         #: Tangent (non-linear + linear) mass matrix of the system in PETSc CSR format
         self.tangent_mass = PETSc.Mat().create(comm=comm)
         #: Non-linear mass matrix of the system in PETSc CSR format
@@ -90,18 +92,12 @@ class DPHS:
         self.stiffness = PETSc.Mat().create(comm=comm)
         #: rhs of the system in PETSc Vec
         self.rhs = PETSc.Vec().create(comm=comm)
-        #: To check if the initial values have been set before time-resolution
-        self.initial_value_set = dict()
         #: To check if the PETSc TS time-integration parameters have been set before time-integration
         self.time_scheme["isset"] = False
         #: For monitoring time in TS resolution
         self.ts_start = 0
         #: Will contain both time t and solution z
-        self.solution = dict()
-        #: Time t where the solution have been saved
-        self.solution["t"] = list()
-        #: Solution z at time t
-        self.solution["z"] = list()
+        self._time_integrator.reset_solution()
         #: To check if the system has been solved
         self.solve_done = False
         #: To stop TS integration by keeping already computed timesteps if one step fails
@@ -129,6 +125,91 @@ class DPHS:
         if rank == 0:
             logging.info(f"A model with {basis_field} unknowns has been initialized")
 
+    @property
+    def domain(self):
+        return self._topology.domain
+
+    @domain.setter
+    def domain(self, value):
+        self._topology.domain = value
+
+    @property
+    def bricks(self):
+        return self._topology.bricks
+
+    @property
+    def states(self):
+        return self._state_space.states
+
+    @property
+    def costates(self):
+        return self._state_space.costates
+
+    @property
+    def ports(self):
+        return self._io_registry.ports
+
+    @property
+    def controls(self):
+        return self._io_registry.controls
+
+    @property
+    def hamiltonian(self):
+        return self._io_registry.hamiltonian
+
+    @property
+    def powers_computed(self):
+        return self._io_registry.powers_computed
+
+    @powers_computed.setter
+    def powers_computed(self, value):
+        self._io_registry.powers_computed = value
+
+    @property
+    def time_scheme(self):
+        return self._time_integrator.options
+
+    @time_scheme.setter
+    def time_scheme(self, value):
+        self._time_integrator.options = value
+
+    @property
+    def initial_value_set(self):
+        return self._time_integrator.initial_values
+
+    @property
+    def solution(self):
+        return self._time_integrator.solution
+
+    @property
+    def stop_TS(self):
+        return self._time_integrator.stop
+
+    @stop_TS.setter
+    def stop_TS(self, value):
+        self._time_integrator.stop = value
+
+    @property
+    def ts_start(self):
+        return self._time_integrator.ts_start
+
+    @ts_start.setter
+    def ts_start(self, value):
+        self._time_integrator.ts_start = value
+
+    def _on_port_registered(self, port: Port) -> None:
+        """Perform DPHS specific bookkeeping after a port has been registered."""
+
+        if not port.get_algebraic():
+            self.initial_value_set.setdefault(port.get_flow(), False)
+
+        where = ""
+        if port.get_region() is not None:
+            where = f"on region {port.get_region()}"
+
+        if rank == 0:
+            logging.info(f"port: {port.get_name()} has been added {where}")
+
     def set_domain(self, domain: Domain):
         """This function sets a domain for the dphs.
 
@@ -139,7 +220,7 @@ class DPHS:
             parameters (dict): parameters for the construction, either for built in, or user-defined auxiliary script
         """
 
-        self.domain = domain
+        self.builder.with_domain(domain)
         if rank == 0:
             logging.info(f"domain: {domain.get_name()} has been set")
 
@@ -150,7 +231,7 @@ class DPHS:
             state (State): the state
         """
 
-        self.states[state.get_name()] = state
+        self.builder.add_state(state)
 
         if rank == 0:
             logging.info(f"state: {state.get_name()} has been added")
@@ -162,31 +243,9 @@ class DPHS:
             costate (CoState): the costate
         """
 
-        # Set the `costate` in its `state`
+        # The builder takes care of wiring the dynamical port for us
+        self.builder.add_costate(costate)
         state = costate.get_state()
-        state.set_costate(costate)
-
-        # Add the `costate` to the list
-        self.costates[costate.get_name()] = costate
-
-        # Define the `port` gathering the `state` and the `costate`
-        port = Port(
-            state.get_name(),
-            state.get_name(),
-            costate.get_name(),
-            costate.get_kind(),
-            state.get_mesh_id(),
-            algebraic=False,
-            dissipative=False,
-            substituted=costate.get_substituted(),
-            region=state.get_region(),
-        )
-        # Add the `port` the the dphs
-        self.add_port(port)
-
-        # Set the `port` in the `state` and the `costate`
-        state.set_port(port)
-        costate.set_port(port)
 
         if rank == 0:
             logging.info(
@@ -203,13 +262,7 @@ class DPHS:
             port (Port): the port
         """
 
-        self.ports[port.get_name()] = port
-        where = ""
-        if port.get_region() is not None:
-            where = f"on region {port.get_region()}"
-
-        if rank == 0:
-            logging.info(f"port: {port.get_name()} has been added {where}")
+        self.builder.add_port(port)
 
     def add_FEM(self, fem: FEM):
         """This function adds a FEM (Finite Element Method) for the variables associated to a port of the dphs

--- a/tests/test_dphs.py
+++ b/tests/test_dphs.py
@@ -1,9 +1,50 @@
 import unittest
+from unittest.mock import Mock
+
+from scrimp import CoState, DPHS, State
 
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, False)  # add assertion here
+class TestDPHSBuilder(unittest.TestCase):
+    def setUp(self):
+        self.dphs = DPHS()
+        self.state = State("x", "displacement", "scalar-field", region=1, mesh_id=0)
+        self.costate = CoState("p", "momentum", self.state)
+
+    def test_set_domain_through_builder(self):
+        domain = Mock()
+        domain.get_name.return_value = "mock-domain"
+
+        self.dphs.set_domain(domain)
+
+        self.assertIs(self.dphs.domain, domain)
+        domain.get_name.assert_called()
+
+    def test_register_state_and_costate(self):
+        self.dphs.add_state(self.state)
+        self.dphs.add_costate(self.costate)
+
+        self.assertIn(self.state.get_name(), self.dphs.states)
+        self.assertIn(self.costate.get_name(), self.dphs.costates)
+        self.assertIn(self.state.get_name(), self.dphs.ports)
+        self.assertIs(self.state.get_port(), self.dphs.ports[self.state.get_name()])
+        self.assertIn(self.state.get_name(), self.dphs.initial_value_set)
+        self.assertFalse(self.dphs.initial_value_set[self.state.get_name()])
+
+    def test_fluent_builder_usage(self):
+        domain = Mock()
+        domain.get_name.return_value = "mock-domain"
+
+        (
+            self.dphs.builder.with_domain(domain)
+            .add_state(self.state)
+            .add_costate(self.costate)
+        )
+
+        self.assertIs(self.dphs.domain, domain)
+        self.assertIn(self.state.get_name(), self.dphs.states)
+        self.assertEqual(self.costate.get_state(), self.state)
+        self.assertIsNotNone(self.state.get_port())
+        self.assertIn(self.state.get_name(), self.dphs.ports)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a ``scrimp.core`` package with topology, state space, time integration and IO dataclasses
- provide a ``TopologyBuilder`` helper and refactor ``DPHS`` to delegate domain/state/port registration through it
- document and exercise the fluent builder workflow with updated tests, docs and a new quickstart example

## Testing
- `pytest` *(fails: missing optional dependency `gmsh` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd7aee110832b89e06bdb76adf19d