### PR TITLE
Refine PETSc assembly pipeline and solver configuration

### DIFF
--- a/scrimp/core/__init__.py
+++ b/scrimp/core/__init__.py
@@ -1,0 +1,8 @@
+"""Core utilities for SCRIMP."""
+
+from .assembly import MatrixAssemblyManager, MatrixAssemblyOptions
+
+__all__ = [
+    "MatrixAssemblyManager",
+    "MatrixAssemblyOptions",
+]

--- a/scrimp/core/assembly.py
+++ b/scrimp/core/assembly.py
@@ -1,0 +1,231 @@
+"""Assembly helpers and caches for PETSc matrices."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Tuple
+
+import numpy as np
+from petsc4py import PETSc
+
+from scrimp.utils.linalg import create_petsc_aij_from_csr, extract_getfem_csr
+
+
+@dataclass
+class SparsityPattern:
+    shape: Tuple[int, int]
+    indptr: np.ndarray
+    indices: np.ndarray
+
+    def matches(self, shape: Tuple[int, int], indptr: np.ndarray, indices: np.ndarray) -> bool:
+        if self.shape != shape:
+            return False
+        return np.array_equal(self.indptr, indptr) and np.array_equal(self.indices, indices)
+
+
+@dataclass
+class MatrixAssemblyOptions:
+    use_gpu: bool = False
+    mat_type: Optional[str] = None
+    asynchronous: bool = False
+    max_workers: int = 2
+
+
+@dataclass
+class AssemblyStatistics:
+    builds: int = 0
+    reuses: int = 0
+
+
+class MatrixAssemblyManager:
+    """Manage PETSc matrix assembly using cached sparsity patterns."""
+
+    def __init__(
+        self,
+        *,
+        comm: PETSc.Comm = PETSc.COMM_WORLD,
+        options: Optional[MatrixAssemblyOptions] = None,
+    ) -> None:
+        self.comm = comm
+        self.options = options or MatrixAssemblyOptions()
+        self._patterns: Dict[str, SparsityPattern] = {}
+        self._matrices: Dict[str, PETSc.Mat] = {}
+        self._lock = threading.RLock()
+        self._executor: Optional[ThreadPoolExecutor] = None
+        self._executor_workers: Optional[int] = None
+        self._stats = AssemblyStatistics()
+
+    # ------------------------------------------------------------------
+    # lifecycle helpers
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
+            self._executor = None
+            self._executor_workers = None
+
+    # ------------------------------------------------------------------
+    # option helpers
+    # ------------------------------------------------------------------
+    def update_options(self, **kwargs) -> None:
+        for key, value in kwargs.items():
+            if hasattr(self.options, key):
+                setattr(self.options, key, value)
+        if not self.options.asynchronous and self._executor is not None:
+            self.close()
+        elif self.options.asynchronous and self._executor is not None:
+            if (
+                self._executor_workers is not None
+                and self.options.max_workers != self._executor_workers
+            ):
+                self.close()
+
+    # ------------------------------------------------------------------
+    # statistics
+    # ------------------------------------------------------------------
+    @property
+    def stats(self) -> AssemblyStatistics:
+        return AssemblyStatistics(self._stats.builds, self._stats.reuses)
+
+    # ------------------------------------------------------------------
+    # matrix retrieval
+    # ------------------------------------------------------------------
+    def get_matrix(self, key: str) -> Optional[PETSc.Mat]:
+        with self._lock:
+            return self._matrices.get(key)
+
+    def register_matrix(self, key: str, matrix: PETSc.Mat) -> None:
+        with self._lock:
+            self._matrices[key] = matrix
+
+    def _preferred_types(self) -> Iterable[str]:
+        if self.options.mat_type:
+            return (self.options.mat_type,)
+        if self.options.use_gpu:
+            return tuple(
+                t
+                for t in (
+                    getattr(PETSc.Mat.Type, "AIJCUSPARSE", None),
+                    getattr(PETSc.Mat.Type, "AIJHIPSPARSE", None),
+                    getattr(PETSc.Mat.Type, "AIJVIENNACL", None),
+                    PETSc.Mat.Type.AIJ,
+                )
+                if t is not None
+            )
+        return (PETSc.Mat.Type.AIJ,)
+
+    def preferred_types(self) -> Iterable[str]:
+        return self._preferred_types()
+
+    # ------------------------------------------------------------------
+    # assembly routines
+    # ------------------------------------------------------------------
+    def assemble_from_getfem(
+        self,
+        key: str,
+        matrix,
+        *,
+        target: Optional[PETSc.Mat] = None,
+        asynchronous: bool = False,
+    ):
+        shape, indptr, indices, values = extract_getfem_csr(matrix)
+        return self.assemble_from_csr(
+            key,
+            shape,
+            indptr,
+            indices,
+            values,
+            target=target,
+            asynchronous=asynchronous,
+        )
+
+    def assemble_from_csr(
+        self,
+        key: str,
+        shape: Tuple[int, int],
+        indptr: np.ndarray,
+        indices: np.ndarray,
+        values: np.ndarray,
+        *,
+        target: Optional[PETSc.Mat] = None,
+        asynchronous: bool = False,
+    ):
+        if asynchronous and self.options.asynchronous:
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(max_workers=self.options.max_workers)
+                self._executor_workers = self.options.max_workers
+            return self._executor.submit(
+                self._assemble_internal,
+                key,
+                shape,
+                indptr.copy(),
+                indices.copy(),
+                values.copy(),
+                target,
+            )
+
+        return self._assemble_internal(key, shape, indptr, indices, values, target)
+
+    # ------------------------------------------------------------------
+    # internal implementation
+    # ------------------------------------------------------------------
+    def _assemble_internal(
+        self,
+        key: str,
+        shape: Tuple[int, int],
+        indptr: np.ndarray,
+        indices: np.ndarray,
+        values: np.ndarray,
+        target: Optional[PETSc.Mat],
+    ) -> PETSc.Mat:
+        with self._lock:
+            pattern = self._patterns.get(key)
+            preferred_types = self._preferred_types()
+
+            if pattern is None or not pattern.matches(shape, indptr, indices):
+                matrix = create_petsc_aij_from_csr(
+                    shape,
+                    indptr,
+                    indices,
+                    values,
+                    comm=self.comm,
+                    mat=target or self._matrices.get(key),
+                    preferred_types=preferred_types,
+                )
+                self._patterns[key] = SparsityPattern(shape, indptr.copy(), indices.copy())
+                self._matrices[key] = matrix
+                self._stats.builds += 1
+                return matrix
+
+            matrix = target or self._matrices.get(key)
+            if matrix is None:
+                matrix = create_petsc_aij_from_csr(
+                    shape,
+                    indptr,
+                    indices,
+                    values,
+                    comm=self.comm,
+                    mat=None,
+                    preferred_types=preferred_types,
+                )
+                self._matrices[key] = matrix
+                self._patterns[key] = SparsityPattern(shape, indptr.copy(), indices.copy())
+                self._stats.builds += 1
+                return matrix
+
+            matrix.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, False)
+            matrix.setValuesCSR(indptr, indices, values)
+            matrix.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, True)
+            matrix.assemble()
+            self._stats.reuses += 1
+            return matrix
+
+
+__all__ = [
+    "AssemblyStatistics",
+    "MatrixAssemblyManager",
+    "MatrixAssemblyOptions",
+    "SparsityPattern",
+]

--- a/scrimp/dphs.py
+++ b/scrimp/dphs.py
@@ -13,7 +13,10 @@
 - brief:            class for distributed port-Hamiltonian system
 """
 
-from scrimp.utils.linalg import convert_gmm_to_petsc, extract_gmm_to_scipy
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from scrimp.utils.linalg import extract_gmm_to_scipy
 from scrimp.hamiltonian import Hamiltonian
 from scrimp.brick import Brick
 from scrimp.control import Control_Port
@@ -22,6 +25,10 @@ from scrimp.port import Parameter, Port
 from scrimp.costate import CoState
 from scrimp.state import State
 from scrimp.domain import Domain
+from scrimp.core.assembly import (
+    MatrixAssemblyManager,
+    MatrixAssemblyOptions,
+)
 from petsc4py import PETSc
 import getfem as gf
 import logging
@@ -42,6 +49,106 @@ max_rank = comm.getSize()
 
 import scrimp.utils.config
 outputs_path = scrimp.utils.config.outputs_path
+
+@dataclass
+class KSPConfig:
+    """Typed configuration for PETSc KSP solver."""
+
+    type: str = "gmres"
+    rtol: Optional[float] = None
+    atol: Optional[float] = None
+    max_it: Optional[int] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    def to_options(self) -> Dict[str, Any]:
+        opts: Dict[str, Any] = {"ksp_type": self.type}
+        if self.rtol is not None:
+            opts["ksp_rtol"] = self.rtol
+        if self.atol is not None:
+            opts["ksp_atol"] = self.atol
+        if self.max_it is not None:
+            opts["ksp_max_it"] = int(self.max_it)
+        opts.update(self.options)
+        return opts
+
+
+@dataclass
+class PCConfig:
+    """Typed configuration for PETSc preconditioner."""
+
+    type: str = "lu"
+    factor_solver_type: str = "mumps"
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    def to_options(self) -> Dict[str, Any]:
+        opts: Dict[str, Any] = {"pc_type": self.type}
+        if self.factor_solver_type:
+            opts["pc_factor_mat_solver_type"] = self.factor_solver_type
+        opts.update(self.options)
+        return opts
+
+
+@dataclass
+class TSConfig:
+    """Typed configuration for PETSc TS solver."""
+
+    type: str = "bdf"
+    order: int = 2
+    equation_type: PETSc.TS.EquationType = PETSc.TS.EquationType.DAE_IMPLICIT_INDEX2
+    t_0: float = 0.0
+    t_f: float = 1.0
+    dt: float = 0.01
+    dt_save: float = 0.01
+    adapt_dt_min: Optional[float] = None
+    adapt_dt_max: Optional[float] = None
+    max_snes_failures: int = -1
+    init_step: bool = True
+    init_step_iterations: int = 1
+    init_step_ts_type: str = "pseudo"
+    init_step_dt: Optional[float] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    def to_options(self, *, max_rank: int) -> Dict[str, Any]:
+        opts: Dict[str, Any] = {
+            "ts_type": self.type,
+            "ts_equation_type": self.equation_type,
+            "t_0": float(self.t_0),
+            "t_f": float(self.t_f),
+            "dt": float(self.dt),
+            "dt_save": float(self.dt_save),
+            "ts_max_snes_failures": int(self.max_snes_failures),
+            "init_step": bool(self.init_step),
+            "init_step_nb_iter": int(self.init_step_iterations),
+            "init_step_ts_type": self.init_step_ts_type,
+        }
+        if self.type == "bdf":
+            opts["ts_bdf_order"] = int(self.order)
+        if self.adapt_dt_min is not None:
+            opts["ts_adapt_dt_min"] = float(self.adapt_dt_min)
+        else:
+            opts["ts_adapt_dt_min"] = 1.0e-2 * float(self.dt) ** 2 / max_rank
+        if self.adapt_dt_max is not None:
+            opts["ts_adapt_dt_max"] = float(self.adapt_dt_max)
+        else:
+            opts["ts_adapt_dt_max"] = float(self.dt_save)
+        if self.init_step_dt is not None:
+            opts["init_step_dt"] = float(self.init_step_dt)
+        else:
+            opts["init_step_dt"] = float(self.dt) ** 2
+        opts.update(self.options)
+        return opts
+
+
+@dataclass
+class SolverOptions:
+    """Container gathering solver configuration."""
+
+    ts: TSConfig = field(default_factory=TSConfig)
+    ksp: KSPConfig = field(default_factory=KSPConfig)
+    pc: PCConfig = field(default_factory=PCConfig)
+    assembly: MatrixAssemblyOptions = field(default_factory=MatrixAssemblyOptions)
+    jacobian_free: bool = False
+
 
 class DPHS:
     """A generic class handling distributed pHs using the GetFEM tools
@@ -76,6 +183,13 @@ class DPHS:
         self.hamiltonian = Hamiltonian("Hamiltonian")
         #: To check if the powers have been computed
         self.powers_computed = False
+        #: Solver options wrapper (KSP/PC/TS/Assembly)
+        self.solver_options = SolverOptions()
+        #: Assembly manager reusing sparsity patterns and configurable backends
+        self.assembly_manager = MatrixAssemblyManager(
+            comm=comm,
+            options=self.solver_options.assembly,
+        )
         #: Tangent (non-linear + linear) mass matrix of the system in PETSc CSR format
         self.tangent_mass = PETSc.Mat().create(comm=comm)
         #: Non-linear mass matrix of the system in PETSc CSR format
@@ -128,6 +242,12 @@ class DPHS:
 
         if rank == 0:
             logging.info(f"A model with {basis_field} unknowns has been initialized")
+
+        # Register matrices for reuse inside the assembly manager
+        self.assembly_manager.register_matrix("mass", self.mass)
+        self.assembly_manager.register_matrix("stiffness", self.stiffness)
+        self.assembly_manager.register_matrix("nl_mass", self.nl_mass)
+        self.assembly_manager.register_matrix("nl_stiffness", self.nl_stiffness)
 
     def set_domain(self, domain: Domain):
         """This function sets a domain for the dphs.
@@ -210,6 +330,30 @@ class DPHS:
 
         if rank == 0:
             logging.info(f"port: {port.get_name()} has been added {where}")
+
+    def _assemble_and_store(
+        self,
+        key: str,
+        attr: str,
+        *,
+        asynchronous: Optional[bool] = None,
+    ) -> PETSc.Mat:
+        """Assemble the current GetFEM matrix into a PETSc matrix and store it."""
+
+        if asynchronous is None:
+            asynchronous = self.solver_options.assembly.asynchronous
+
+        result = self.assembly_manager.assemble_from_getfem(
+            key,
+            self.gf_model.tangent_matrix(),
+            target=getattr(self, attr),
+            asynchronous=asynchronous,
+        )
+
+        matrix = result.result() if hasattr(result, "result") else result
+        setattr(self, attr, matrix)
+        self.assembly_manager.register_matrix(key, matrix)
+        return matrix
 
     def add_FEM(self, fem: FEM):
         """This function adds a FEM (Finite Element Method) for the variables associated to a port of the dphs
@@ -573,11 +717,7 @@ class DPHS:
                 brick.enable_id_bricks(self.gf_model)
 
         self.gf_model.assembly(option="build_matrix")
-        
-        convert_gmm_to_petsc(
-            self.gf_model.tangent_matrix(),
-            self.mass,
-        )
+        self._assemble_and_store("mass", "mass")
 
         self.disable_all_bricks()
 
@@ -600,11 +740,7 @@ class DPHS:
                 brick.enable_id_bricks(self.gf_model)
 
         self.gf_model.assembly(option="build_matrix")
-        
-        convert_gmm_to_petsc(
-            self.gf_model.tangent_matrix(),
-            self.stiffness,
-        )
+        self._assemble_and_store("stiffness", "stiffness")
 
         self.disable_all_bricks()
 
@@ -642,11 +778,7 @@ class DPHS:
                 brick.enable_id_bricks(self.gf_model)
 
         self.gf_model.assembly(option="build_matrix")
-        
-        convert_gmm_to_petsc(
-            self.gf_model.tangent_matrix(),
-            self.nl_mass,
-        )
+        self._assemble_and_store("nl_mass", "nl_mass")
         self.tangent_mass = self.mass.copy()
         self.tangent_mass.axpy(1, self.nl_mass)
 
@@ -666,11 +798,7 @@ class DPHS:
                 brick.enable_id_bricks(self.gf_model)
 
         self.gf_model.assembly(option="build_matrix")
-        
-        convert_gmm_to_petsc(
-            self.gf_model.tangent_matrix(),
-            self.nl_stiffness,
-        )
+        self._assemble_and_store("nl_stiffness", "nl_stiffness")
         self.tangent_stiffness = self.stiffness.copy()
         self.tangent_stiffness.axpy(1, self.nl_stiffness)
 
@@ -740,6 +868,15 @@ class DPHS:
         if not self.linear_stiffness:
             self.assemble_nl_stiffness()
 
+        if self.solver_options.jacobian_free:
+            P.zeroEntries()
+            P.axpy(1.0, self.tangent_stiffness)
+            P.axpy(sig, self.tangent_mass)
+            P.assemble()
+            if A != P:
+                A.assemble()
+            return PETSc.Mat.Structure.SAME_NONZERO_PATTERN
+
         self.tangent_stiffness.copy(P)
         P.axpy(sig, self.tangent_mass)
 
@@ -747,6 +884,7 @@ class DPHS:
             if rank == 0:
                 logging.info("Operator different from preconditioning")
             A.assemble()
+        return PETSc.Mat.Structure.SAME_NONZERO_PATTERN
 
     def init_matrix(self,A):
         """
@@ -758,24 +896,34 @@ class DPHS:
 
         """
 
-        A.setSizes(self.gf_model.nbdof())
+        size = self.gf_model.nbdof()
+        A.setSizes((size, size))
         A.setOption(PETSc.Mat.Option.FORCE_DIAGONAL_ENTRIES, True)
-        A.setType("aij")
+
+        for mat_type in self.assembly_manager.preferred_types():
+            try:
+                A.setType(mat_type)
+                break
+            except PETSc.Error as exc:  # pragma: no cover - depends on PETSc build
+                logging.warning(
+                    "Failed to initialise PETSc matrix as '%s': %s. Trying next backend.",
+                    mat_type,
+                    exc,
+                )
         A.setUp()
-        x=A.createVecRight(); x.setArray(0)
-        A.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR,False)
-        A.setDiagonal(x,addv=PETSc.InsertMode.ADD_VALUES)
-        A.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR,True)
+        diagonal = A.createVecRight()
+        diagonal.set(0.0)
+        A.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, False)
+        A.setDiagonal(diagonal, addv=PETSc.InsertMode.ADD_VALUES)
+        A.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, True)
         A.assemble()
 
     def allocate_memory(self):
         """Pre-allocate memory for matrices and vectors"""
 
-        self.mass.bindToCPU(True)
         self.init_matrix(self.mass)
         self.init_matrix(self.nl_mass)
         self.init_matrix(self.tangent_mass)
-        self.stiffness.bindToCPU(True)
         self.init_matrix(self.stiffness)
         self.init_matrix(self.nl_stiffness)
         self.init_matrix(self.tangent_stiffness)
@@ -795,68 +943,59 @@ class DPHS:
         for key in self.time_scheme.getAll():
             self.time_scheme.delValue(key)
 
-    def set_time_scheme(self, **kwargs):
-        """Allows an easy setting of the PETSc TS environment
+    def _update_assembly_options(self, assembly: MatrixAssemblyOptions) -> None:
+        current = self.solver_options.assembly
+        current.use_gpu = assembly.use_gpu
+        current.mat_type = assembly.mat_type
+        current.asynchronous = assembly.asynchronous
+        current.max_workers = assembly.max_workers
+        self.assembly_manager.update_options(
+            use_gpu=current.use_gpu,
+            mat_type=current.mat_type,
+            asynchronous=current.asynchronous,
+            max_workers=current.max_workers,
+        )
 
-        Args:
-            **kwargs: PETSc TS options and more (see examples)
-        """
+    def _apply_solver_options(self) -> None:
+        ts_options = self.solver_options.ts.to_options(max_rank=max_rank)
+        for key, value in ts_options.items():
+            self.time_scheme[key] = value
+
+        for key, value in self.solver_options.ksp.to_options().items():
+            self.time_scheme[key] = value
+
+        for key, value in self.solver_options.pc.to_options().items():
+            self.time_scheme[key] = value
+
+        self.time_scheme["isset"] = True
+
+    def set_time_scheme(
+        self,
+        *,
+        ts: Optional[TSConfig] = None,
+        ksp: Optional[KSPConfig] = None,
+        pc: Optional[PCConfig] = None,
+        assembly: Optional[MatrixAssemblyOptions] = None,
+        jacobian_free: Optional[bool] = None,
+        **kwargs,
+    ):
+        """Configure PETSc TS/KSP/PC options using typed configuration objects."""
+
+        if ts is not None:
+            self.solver_options.ts = ts
+        if ksp is not None:
+            self.solver_options.ksp = ksp
+        if pc is not None:
+            self.solver_options.pc = pc
+        if assembly is not None:
+            self._update_assembly_options(assembly)
+        if jacobian_free is not None:
+            self.solver_options.jacobian_free = bool(jacobian_free)
+
+        self._apply_solver_options()
 
         for key, value in kwargs.items():
             self.time_scheme[key] = value
-
-        if not self.time_scheme.hasName("ts_equation_type"):
-            self.time_scheme[
-                "ts_equation_type"
-            ] = PETSc.TS.EquationType.DAE_IMPLICIT_INDEX2
-
-        if not self.time_scheme.hasName("ts_type") and not self.time_scheme.hasName(
-            "ts_ssp"
-        ):
-            self.time_scheme["ts_type"] = "bdf"
-            self.time_scheme["ts_bdf_order"] = 2
-
-        if not self.time_scheme.hasName("ksp_type"):
-            self.time_scheme["ksp_type"] = "gmres"
-
-        if not self.time_scheme.hasName("pc_type"):
-            self.time_scheme["pc_type"] = "lu"
-
-        if not self.time_scheme.hasName("pc_factor_mat_solver_type"):
-            self.time_scheme["pc_factor_mat_solver_type"] = "mumps"
-
-        if not self.time_scheme.hasName("t_0"):
-            self.time_scheme["t_0"] = 0.0
-
-        if not self.time_scheme.hasName("t_f"):
-            self.time_scheme["t_f"] = 1.0
-
-        if not self.time_scheme.hasName("dt"):
-            self.time_scheme["dt"] = 0.01
-
-        if not self.time_scheme.hasName("dt_save"):
-            self.time_scheme["dt_save"] = 0.01
-
-        if not self.time_scheme.hasName("ts_adapt_dt_min"):
-            self.time_scheme["ts_adapt_dt_min"] = 1.e-2*float(self.time_scheme["dt"])**2 / max_rank
-            
-        if not self.time_scheme.hasName("ts_adapt_dt_max"):
-            self.time_scheme["ts_adapt_dt_max"] = float(self.time_scheme["dt_save"])
-
-        if not self.time_scheme.hasName("ts_max_snes_failures"):
-            self.time_scheme["ts_max_snes_failures"] = -1
-        
-        if not self.time_scheme.hasName("init_step"):
-            self.time_scheme["init_step"] = True
-
-        if not self.time_scheme.hasName("init_step_nb_iter"):
-            self.time_scheme["init_step_nb_iter"] = 1
-
-        if not self.time_scheme.hasName("init_step_ts_type"):
-            self.time_scheme["init_step_ts_type"] = "pseudo"
-
-        if not self.time_scheme.hasName("init_step_dt"):
-            self.time_scheme["init_step_dt"] = float(self.time_scheme["dt"])**2
 
         self.time_scheme["isset"] = True
 
@@ -973,8 +1112,16 @@ class DPHS:
         self.assemble_rhs()
 
         # PETSc TS Jacobian and residual
-        self.J = self.tangent_stiffness.duplicate()
-        self.J.assemble()
+        if self.solver_options.jacobian_free:
+            try:
+                self.J = PETSc.Mat().createSNESMF()
+            except AttributeError:  # pragma: no cover - depends on PETSc build
+                self.J = PETSc.Mat().create(comm=comm)
+                self.J.setType(PETSc.Mat.Type.SHELL)
+                self.J.setUp()
+        else:
+            self.J = self.tangent_stiffness.duplicate()
+            self.J.assemble()
 
         self.F = self.rhs.duplicate()
         self.F.assemble()
@@ -990,6 +1137,12 @@ class DPHS:
 
         # TS
         TS = PETSc.TS().create(comm=comm)
+
+        if self.solver_options.jacobian_free:
+            try:
+                TS.getSNES().setUseFD(True)
+            except AttributeError:  # pragma: no cover - depends on PETSc build
+                pass
 
         def monitor(TS, i, t, z):
             return self.monitor(

--- a/scrimp/utils/linalg.py
+++ b/scrimp/utils/linalg.py
@@ -14,6 +14,9 @@
 """
 
 import sys
+import logging
+from typing import Callable, Iterable, Optional, Sequence, Tuple
+
 import getfem as gf
 import numpy as np
 import petsc4py
@@ -21,36 +24,170 @@ from slepc4py import SLEPc
 
 petsc4py.init(sys.argv)
 from petsc4py import PETSc
+
 PETSc.Options().setValue('info', None)
 
 comm = PETSc.COMM_WORLD
 import scipy.sparse as sp
 
-def convert_gmm_to_petsc(M, B, comm=comm):
-    """Convert a GetFEM matrix M to a PETSc one B
+logger = logging.getLogger(__name__)
+
+
+def _ensure_int_array(array: Sequence[int]) -> np.ndarray:
+    """Return a contiguous numpy array compatible with PETSc indices."""
+
+    if isinstance(array, np.ndarray) and array.dtype == PETSc.IntType:
+        return array
+    return np.asarray(array, dtype=PETSc.IntType)
+
+
+def _ensure_scalar_array(array: Sequence[float]) -> np.ndarray:
+    """Return a contiguous numpy array compatible with PETSc scalar storage."""
+
+    if isinstance(array, np.ndarray) and array.dtype == PETSc.ScalarType:
+        return array
+    return np.asarray(array, dtype=PETSc.ScalarType)
+
+
+def _infer_shape_from_spmat(spmat: gf.Spmat, indptr: Sequence[int], indices: Sequence[int]) -> Tuple[int, int]:
+    """Infer the matrix shape using GetFEM meta-data when available."""
+
+    for attr in ("size", "sizes"):
+        getter = getattr(spmat, attr, None)
+        if getter is None:
+            continue
+        try:
+            shape = getter()
+        except TypeError:
+            shape = getter
+        if isinstance(shape, (tuple, list)) and len(shape) == 2:
+            return int(shape[0]), int(shape[1])
+
+    n_rows = len(indptr) - 1
+    if len(indices):
+        n_cols = int(np.max(indices)) + 1
+    else:
+        n_cols = n_rows
+    return int(n_rows), int(n_cols)
+
+
+def extract_getfem_csr(M: gf.Spmat) -> Tuple[Tuple[int, int], np.ndarray, np.ndarray, np.ndarray]:
+    """Extract the CSR representation from a GetFEM sparse matrix."""
+
+    A = gf.Spmat("copy", M)
+    A.transpose()
+    A.to_csc()
+
+    indptr, indices = A.csc_ind()
+    values = A.csc_val()
+
+    indptr_arr = _ensure_int_array(indptr)
+    indices_arr = _ensure_int_array(indices)
+    values_arr = _ensure_scalar_array(values)
+
+    shape = _infer_shape_from_spmat(A, indptr_arr, indices_arr)
+
+    return shape, indptr_arr, indices_arr, values_arr
+
+
+def create_petsc_aij_from_csr(
+    shape: Tuple[int, int],
+    indptr: Sequence[int],
+    indices: Sequence[int],
+    values: Sequence[float],
+    *,
+    comm: PETSc.Comm = comm,
+    mat: Optional[PETSc.Mat] = None,
+    preferred_types: Optional[Iterable[str]] = None,
+) -> PETSc.Mat:
+    """Create or update a PETSc AIJ matrix from CSR data."""
+
+    rowptr = _ensure_int_array(indptr)
+    colidx = _ensure_int_array(indices)
+    data = _ensure_scalar_array(values)
+
+    if preferred_types is None:
+        preferred_types = (PETSc.Mat.Type.AIJ,)
+
+    if mat is None:
+        mat = PETSc.Mat().create(comm=comm)
+        mat.setSizes(shape)
+
+        for mat_type in preferred_types:
+            try:
+                mat.setType(mat_type)
+                break
+            except PETSc.Error as exc:  # pragma: no cover - depends on PETSc build
+                logger.warning(
+                    "Failed to set PETSc matrix type '%s': %s. Falling back to next candidate.",
+                    mat_type,
+                    exc,
+                )
+        mat.setPreallocationCSR((rowptr, colidx))
+    else:
+        # Ensure sizes are up to date before setting new values
+        mat.setSizes(shape)
+
+    mat.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, False)
+    mat.setValuesCSR(rowptr, colidx, data)
+    mat.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, True)
+    mat.assemble()
+
+    return mat
+
+
+def _collect_preferred_types(mat_type: Optional[str], use_gpu: bool) -> Tuple[str, ...]:
+    if mat_type:
+        return (mat_type,)
+
+    if not use_gpu:
+        return (PETSc.Mat.Type.AIJ,)
+
+    gpu_candidates = []
+    for candidate in ("AIJCUSPARSE", "AIJHIPSPARSE", "AIJVIENNACL"):
+        value = getattr(PETSc.Mat.Type, candidate, None)
+        if value is not None:
+            gpu_candidates.append(value)
+
+    gpu_candidates.append(PETSc.Mat.Type.AIJ)
+    return tuple(gpu_candidates)
+
+
+def convert_gmm_to_petsc(
+    M: gf.Spmat,
+    B: Optional[PETSc.Mat] = None,
+    *,
+    comm: PETSc.Comm = comm,
+    use_gpu: bool = False,
+    mat_type: Optional[str] = None,
+) -> PETSc.Mat:
+    """Convert a GetFEM matrix ``M`` to a PETSc ``Mat``.
 
     Args:
         M (SPMat GetFEM): matrix to transfer
-        B (PETSc.Mat): matrix to fill M with
+        B (PETSc.Mat, optional): matrix to fill with the data from ``M``. If ``None``
+            a new matrix is created.
         comm (MPI_Comm): MPI communicator
+        use_gpu (bool): request a GPU matrix implementation when available
+        mat_type (str, optional): force a specific PETSc matrix type
 
     Returns:
-        None
+        PETSc.Mat: populated PETSc matrix
     """
 
-    A = gf.Spmat("copy", M)
-    # Because CSR is CSC of the transpose
-    # and CSR is not available in getfem
-    A.transpose()
-    row_ptr, col_idx = A.csc_ind()
-    values = A.csc_val()
-    
-    B.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR,False)
-    B.setValuesLocalCSR(row_ptr, col_idx, values, addv=PETSc.InsertMode.INSERT_VALUES)
-    B.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR,True)
+    shape, indptr, indices, values = extract_getfem_csr(M)
 
-    # Assemble the PETSc matrix in parallel
-    B.assemble()
+    preferred_types = _collect_preferred_types(mat_type, use_gpu)
+
+    return create_petsc_aij_from_csr(
+        shape,
+        indptr,
+        indices,
+        values,
+        comm=comm,
+        mat=B,
+        preferred_types=preferred_types,
+    )
 
 def extract_gmm_to_scipy(I, J, M):
     """Extract a sub-matrix A from M, on interval I, J
@@ -103,6 +240,38 @@ def convert_PETSc_to_scipy(A):
     A_scipy = sp.csr_matrix((val, indices, indrow), shape=A.size)
 
     return A_scipy
+
+
+class _ShellContext:
+    """Helper context for PETSc matrix-free shell operators."""
+
+    def __init__(self, action: Callable[[PETSc.Vec, PETSc.Vec], None], diagonal: Optional[PETSc.Vec] = None):
+        self.action = action
+        self.diagonal = diagonal
+
+    def mult(self, mat: PETSc.Mat, x: PETSc.Vec, y: PETSc.Vec) -> None:
+        self.action(x, y)
+
+
+def create_shell_matrix(
+    shape: Tuple[int, int],
+    action: Callable[[PETSc.Vec, PETSc.Vec], None],
+    *,
+    comm: PETSc.Comm = comm,
+    diagonal: Optional[PETSc.Vec] = None,
+) -> PETSc.Mat:
+    """Create a PETSc matrix-free shell matrix with an optional diagonal."""
+
+    shell = PETSc.Mat().create(comm=comm)
+    shell.setSizes(shape)
+    shell.setType(PETSc.Mat.Type.PYTHON)
+    shell.setPythonContext(_ShellContext(action, diagonal))
+    shell.setUp()
+
+    if diagonal is not None:
+        shell.setDiagonal(diagonal, addv=PETSc.InsertMode.INSERT_VALUES)
+
+    return shell
 
 def monitor_EPS_short(EPS, it, nconv, eig, err,it_skip):
     """

--- a/tests/perf/test_assembly_manager.py
+++ b/tests/perf/test_assembly_manager.py
@@ -1,0 +1,61 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+petsc4py = pytest.importorskip("petsc4py")
+from petsc4py import PETSc
+
+from scrimp.core.assembly import MatrixAssemblyManager, MatrixAssemblyOptions
+
+
+def _csr_identity(n: int):
+    indptr = np.arange(n + 1, dtype=PETSc.IntType)
+    indices = np.arange(n, dtype=PETSc.IntType)
+    values = np.ones(n, dtype=PETSc.ScalarType)
+    return (n, n), indptr, indices, values
+
+
+@pytest.mark.perf
+def test_sparsity_cache_reuse():
+    manager = MatrixAssemblyManager()
+    shape, indptr, indices, values = _csr_identity(4)
+
+    matrix = manager.assemble_from_csr("mass", shape, indptr, indices, values)
+    assert matrix.getSize() == shape
+
+    new_values = np.full_like(values, 2.0)
+    matrix_again = manager.assemble_from_csr("mass", shape, indptr, indices, new_values)
+
+    assert matrix_again is matrix
+    _, _, assembled_values = matrix_again.getValuesCSR()
+    np.testing.assert_allclose(assembled_values, new_values)
+
+    stats = manager.stats
+    assert stats.builds == 1
+    assert stats.reuses == 1
+    manager.close()
+
+
+@pytest.mark.perf
+def test_async_assembly_future():
+    options = MatrixAssemblyOptions(asynchronous=True, max_workers=1)
+    manager = MatrixAssemblyManager(options=options)
+    shape, indptr, indices, values = _csr_identity(5)
+
+    future = manager.assemble_from_csr(
+        "stiffness", shape, indptr, indices, values, asynchronous=True
+    )
+
+    matrix = future.result()
+    assert matrix is manager.get_matrix("stiffness")
+    manager.close()
+
+
+@pytest.mark.perf
+def test_gpu_backend_preference():
+    options = MatrixAssemblyOptions(use_gpu=True)
+    manager = MatrixAssemblyManager(options=options)
+    shape, indptr, indices, values = _csr_identity(3)
+
+    matrix = manager.assemble_from_csr("gpu", shape, indptr, indices, values)
+    assert matrix.getType() in tuple(manager.preferred_types())
+    manager.close()


### PR DESCRIPTION
## Summary
- refactor the linear algebra helpers to build PETSc matrices through createAIJ and optional shell backends with GPU-aware fallbacks
- add a reusable matrix assembly manager that caches sparsity patterns and supports asynchronous updates and GPU preferences
- extend DPHS with typed solver configurations, assembly-manager integration, and optional Jacobian-free Newton–Krylov support, plus new performance-focused tests exercising the cache

## Testing
- pytest tests/perf/test_assembly_manager.py -k reuse

------
https://chatgpt.com/codex/tasks/task_e_68dbd910a634832b9db35bddd6fb7a40