### PR TITLE
Use relative imports in GUI module

### DIFF
--- a/scrimp/GUI.py
+++ b/scrimp/GUI.py
@@ -2,7 +2,7 @@ import re
 import sys
 from PyQt5 import QtWidgets
 import json
-from GUI import (
+from .GUI import (
     welcome_page,
     load_page,
     create_dphs_page,
@@ -21,7 +21,7 @@ from GUI import (
     generate_code_page,
     export_variable_page,
 )
-from utils.GUI import (
+from .utils.GUI import (
     heading,
     black_listed_words,
     text_create_class,


### PR DESCRIPTION
## Summary
- switch GUI module to use package-relative imports for its page and helper modules

## Testing
- QT_QPA_PLATFORM=offscreen python -m scrimp.GUI *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68dbf63eafd8832b8be5161488a14e42