### PR TITLE
Initialize DPHS solver and assembly managers

### DIFF
--- a/scrimp/dphs.py
+++ b/scrimp/dphs.py
@@ -182,6 +182,12 @@ class DPHS:
             port_callback=self._on_port_registered,
         )
 
+        #: Solver configuration and associated assembly manager
+        self.solver_options = SolverOptions()
+        self.assembly_manager = MatrixAssemblyManager(
+            options=self.solver_options.assembly
+        )
+
         #: Clear and init `time_scheme` member, which embed PETSc TS options database
         self._time_integrator = TimeIntegrator()
         self.get_cleared_TS_options()


### PR DESCRIPTION
## Summary
- instantiate SolverOptions and MatrixAssemblyManager at the start of DPHS initialization
- ensure matrices register against a ready assembly manager using the solver's assembly options

## Testing
- `PYTHONPATH=. python examples/wave.py` *(fails: missing numpy dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfa39d9a4832b990224318b64c49b