### PR TITLE
Fix tensor parameter initialization reshape in DPHS

### DIFF
--- a/scrimp/dphs.py
+++ b/scrimp/dphs.py
@@ -568,6 +568,9 @@ class DPHS:
         # Check the size of the parameter according to its kind
         kind = self.ports[name_port].get_parameter(name).get_kind()
         if kind == "tensor-field":
+            evaluation = evaluation.reshape(
+                evaluation.shape[0] * evaluation.shape[1], evaluation.shape[2]
+            )
             sizes = evaluation.shape[0]
         elif kind == "scalar-field":
             sizes = 1


### PR DESCRIPTION
## Summary
- reshape tensor-field parameter evaluations so their leading tensor axes are flattened before registering with GetFEM
- recompute the data size from the reshaped tensor to match GetFEM's expectations

## Testing
- python examples/wave.py *(fails: ModuleNotFoundError: No module named 'scrimp')*


------
https://chatgpt.com/codex/tasks/task_e_68dbfdcc5f90832b8cfdbbd6dd267dc8